### PR TITLE
Update tensorboard dependency version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ultralytics/yolov5:latest
 
 RUN conda install -yq nodejs
 
-RUN pip install -q tensorboard==2.2.2
+RUN pip install -q tensorboard==2.2.1
 RUN pip install -q jupyterlab jupyter_tensorboard ipywidgets
 
 RUN jupyter nbextension enable --py widgetsnbextension

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ultralytics/yolov5:latest
 
 RUN conda install -yq nodejs
 
-RUN pip install -q tensorboard==2.2 
+RUN pip install -q tensorboard==2.2.2
 RUN pip install -q jupyterlab jupyter_tensorboard ipywidgets
 
 RUN jupyter nbextension enable --py widgetsnbextension


### PR DESCRIPTION
Earliest version that breaks is `2.3`. Currently, it should be alright to have previous versions of tensorboard. I've briefly checked till tensorboard `1.0`. However, I have not done any conclusive tests, so I'll leave it at the latest possible version for now which is `2.2.2`. 

This line should not be changed till `jupyter_tensorboard` fixes how they access the `tensorboard` api.